### PR TITLE
Added installation description to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # CronReminderDueCourses
+
+Installation:
+
+1. Download (If you downloaded the zip file, extract it.) 
+2. Rename folder to <b>CronReminderDueCourses</b>
+3. Copy folder to &lt;ilias root path&gt;/Customizing/global/plugins/Services/Cron/CronHook/
+4. Open browser at http://your-ilias/ and navigate to <b>Administration -> Plugins</b>


### PR DESCRIPTION
I added a short installation description, because my workmate had some trouble. He got errors because of the folder name and i think he will not be the only one, who may struggle with this problem.